### PR TITLE
updating OS image to Fedora 35

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "fedora/34-cloud-base"
-  config.vm.box_version = "34.20210423.0"
+  config.vm.box = "fedora/35-cloud-base"
+  config.vm.box_version = "35.20211026.0"
   #  configure as public network for other devices find this instance
   config.vm.network "public_network"
   config.vm.hostname = "roonux"


### PR DESCRIPTION
using Fedora 35 cloud base available in the vagrantboxes. Tested via
vagrant up, no changes needed.

Signed-off-by: blinkst <blinkst@esquibits.com>