### PR TITLE
fedora 39 update

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "fedora/36-cloud-base"
-  config.vm.box_version = "36-20220504.1"
+  config.vm.box = "fedora/39-cloud-base"
+  config.vm.box_version = "39.20231031.1"
   #  configure as public network for other devices find this instance
   config.vm.network "public_network"
   config.vm.hostname = "roonux"

--- a/fedora-setup.sh
+++ b/fedora-setup.sh
@@ -14,7 +14,7 @@ dnf -y update
 # get the roonserver install script, make it run and clean it up
 [[ ! -f roonserver-installer-linuxx64.sh ]] && \
     wget http://download.roonlabs.com/builds/roonserver-installer-linuxx64.sh
-yes yes|sh roonserver-installer-linuxx64.sh
+yes yes | bash roonserver-installer-linuxx64.sh
 rm roonserver-installer-linuxx64.sh
 # restore selinux security context for Roon Server
 /sbin/restorecon /opt/RoonServer/start.sh


### PR DESCRIPTION
Updated to fedora 39 as fedora 40 is having issues with simple booting. Fedora 39 was booted and tested to show in the roon server selection. This means it's ready to use in new setups.