### PR TITLE
Roonux update to fedora cloud 41

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "fedora/39-cloud-base"
-  config.vm.box_version = "39.20231031.1"
+  config.vm.box = "fedora/41-cloud-base"
   #  configure as public network for other devices find this instance
   config.vm.network "public_network"
   config.vm.hostname = "roonux"

--- a/fedora-setup.sh
+++ b/fedora-setup.sh
@@ -14,6 +14,8 @@ dnf -y update
 # get the roonserver install script, make it run and clean it up
 [[ ! -f roonserver-installer-linuxx64.sh ]] && \
     wget http://download.roonlabs.com/builds/roonserver-installer-linuxx64.sh
+#remove deprecated option --show-progress from wget call
+sed -i 's/wget --show-progress/wget/gi' roonserver-installer-linuxx64.sh
 yes yes | bash roonserver-installer-linuxx64.sh
 rm roonserver-installer-linuxx64.sh
 # restore selinux security context for Roon Server


### PR DESCRIPTION
- Vagrant box update to fedora/41-cloud-base.
- Fix a Roon installer error when it attempts to use a deprecated wget flag.